### PR TITLE
Adds tests and makes sure errors are not swallowed

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,22 @@
 
 var Source = require('pull-defer/source')
-var pull = require('pull-stream')
+var error = require('pull-stream/sources/error')
+var values = require('pull-stream/sources/values')
+var collect = require('pull-stream/sinks/collect')
 
 module.exports = function (compare) {
-
   var source = Source()
 
-  var sink = pull.collect(function (err, ary) {
-    source.resolve(pull.values(ary.sort(compare)))
+  var sink = collect(function (err, ary) {
+    if (err) {
+      return source.resolve(error(err))
+    }
+
+    source.resolve(values(ary.sort(compare)))
   })
 
   return function (read) {
     sink(read)
     return source
   }
-
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,13 @@
     "type": "git",
     "url": "git://github.com/dominictarr/pull-sort.git"
   },
-  "dependencies": {},
-  "devDependencies": {},
+  "dependencies": {
+    "pull-defer": "^0.2.3",
+    "pull-stream": "^3.6.9"
+  },
+  "devDependencies": {
+    "tape": "^4.9.1"
+  },
   "scripts": {
     "test": "set -e; for t in test/*.js; do node $t; done"
   },

--- a/test/sort.js
+++ b/test/sort.js
@@ -1,0 +1,28 @@
+var tape = require('tape')
+var sort = require('../')
+var pull = require('pull-stream')
+
+tape('sort an array', function (t) {
+  pull(
+    pull.values([3, 2, 1]),
+    sort(),
+    pull.collect(function (err, values) {
+      t.notOk(err)
+      t.deepEqual(values, [1, 2, 3])
+      t.end()
+    })
+  )
+})
+
+tape('do not swallow errors', function (t) {
+  var error = new Error('Something went wrong')
+
+  pull(
+    pull.error(error),
+    sort(),
+    pull.collect(function (err, values) {
+      t.deepEqual(err, error)
+      t.end()
+    })
+  )
+})


### PR DESCRIPTION
If a pull-stream source/through in the pipeline before a `pull-sort` step results in an error, the error is swallowed and an empty array is passed on to the next step.

This PR:

1. Ensures the error is passed on instead
1. Adds some tests for that & the happy path
1. Adds missing dependencies
1. Ensures this module won't pull in all of `pull-stream` as described in the `pull-stream` readme under [minimal bundle](https://github.com/pull-stream/pull-stream#minimal-bundle).